### PR TITLE
Allow oj 3.x to be used

### DIFF
--- a/gmaps_geocoding.gemspec
+++ b/gmaps_geocoding.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'rest-client', '~> 2.0', '>= 2.0.0'
-  s.add_runtime_dependency 'oj', '~> 2.18', '>= 2.18.0'
+  s.add_runtime_dependency 'oj', '< 4', '>= 2.18.0'
   s.add_runtime_dependency 'oj_mimic_json', '~> 1.0', '>= 1.0.1'
   s.add_runtime_dependency 'ox', '~> 2.4', '>= 2.4.7'
   s.add_runtime_dependency 'json', '~> 2.0', '>= 2.0.2'

--- a/gmaps_geocoding.gemspec
+++ b/gmaps_geocoding.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.email = ['christian.kakesa@gmail.com']
   s.description = <<-END
     A simple Ruby gem for Google Maps Geocoding API.
-    This gem return a Ruby Hash object of the result.
+    This gem returns a Ruby Hash object of the result.
   END
   s.summary = 'Use Google Geocoding API from Ruby.'
   s.homepage = 'https://github.com/fenicks/gmaps_geocoding'

--- a/lib/gmaps_geocoding/version.rb
+++ b/lib/gmaps_geocoding/version.rb
@@ -1,3 +1,3 @@
 module GmapsGeocoding
-  VERSION = '1.3.3'.freeze
+  VERSION = '1.3.4'.freeze
 end


### PR DESCRIPTION
Allow for OJ version 3 as the latest version 2 release is over a year old.